### PR TITLE
Feature middleware types

### DIFF
--- a/config/psr15middleware.php
+++ b/config/psr15middleware.php
@@ -1,24 +1,16 @@
 <?php
 return [
     'middleware' => [
-
-        \Jshannon63\Psr15Middleware\exampleMiddleware::class,
-
+        [\Jshannon63\Psr15Middleware\exampleMiddleware::class, 'after'],
     ],
     'groups' => [
         'web' => [
-
-
         ],
         'api' => [
-
-
         ],
         'custom' => [
-
         ],
     ],
     'aliases' => [
-
     ]
 ];

--- a/config/psr15middleware.php
+++ b/config/psr15middleware.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'middleware' => [
-        [\Jshannon63\Psr15Middleware\exampleMiddleware::class, 'after'],
+        [\Jshannon63\Psr15Middleware\exampleMiddleware::class, 'prepend', 'after'],
     ],
     'groups' => [
         'web' => [

--- a/src/Psr15Middleware.php
+++ b/src/Psr15Middleware.php
@@ -12,30 +12,33 @@ class Psr15Middleware
     public function __construct($middleware, $mode = 'before')
     {
         $this->middleware = $middleware;
+        $this->mode = $mode;
     }
 
-    public function handle($request, Closure $next)
+    public function handle($request, Closure $next, ...$parameters)
     {
         $dispatcher = new Dispatcher;
 
         if ($this->mode == 'before') {
-            // we create a throw-away response object since PSR-15 requires it but it is not
-            // truly available at this point in the request cycle.
-            $dispatcher($request, (new \Symfony\Component\HttpFoundation\Response), $this->middleware);
-            return $next($request);
+            // we must create a mock response object since PSR-15 requires it
+            // but it is not truly available at this point in the request cycle.
+            // so we will ignore it when returned.
+            $messages = $dispatcher($request, (new \Symfony\Component\HttpFoundation\Response), $this->middleware, ...$parameters);
+            return $next($messages['request']);
         } elseif ($this->mode == 'after') {
             $response = $next($request);
-            return $dispatcher($request, $response, $this->middleware);
+            $messages = $dispatcher($request, $response, $this->middleware, ...$parameters);
+            return $messages['response'];
         } else {
             return $next($request);
         }
     }
 
-    public function terminate($request, $response)
+    public function terminate($request, $response, ...$parameters)
     {
         if ($this->mode == 'terminable') {
             $dispatcher = new Dispatcher;
-            $dispatcher($request, $response, $this->middleware);
+            $dispatcher($request, $response, $this->middleware, ...$parameters);
         }
     }
 }

--- a/src/Psr15MiddlewareDispatcher.php
+++ b/src/Psr15MiddlewareDispatcher.php
@@ -9,35 +9,64 @@ use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 
 class Dispatcher
 {
-    public function __invoke(FoundationRequest $request, FoundationResponse $response, $middleware)
+    public function __invoke(FoundationRequest $request, FoundationResponse $response, $middleware, ...$parameters)
     {
         $psr7request = (new DiactorosFactory())->createRequest($request);
 
         $requestHandler = new Handler($response);
 
-        if (is_callable($item)) {
-            $psr7response = $item()->process($requestHandler->getRequest(), $requestHandler);
-        } elseif (is_object($item)) {
-            $psr7response = $item->process($requestHandler->getRequest(), $requestHandler);
+        if (is_callable($middleware)) {
+            $psr7response = $middleware()->process($psr7request, $requestHandler);
+        } elseif (is_object($middleware)) {
+            $psr7response = $middleware->process($psr7request, $requestHandler);
         } else {
-            $psr7response = (new $item)->process($requestHandler->getRequest(), $requestHandler);
+            $psr7response = (new $middleware(...$parameters))->process($psr7request, $requestHandler);
         }
 
-        return $this->convertResponse($psr7response, $response);
+        return [
+            'request' => $this->convertRequest($requestHandler->getRequest(), $request),
+            'response' => $this->convertResponse($psr7response, $response)
+        ];
+    }
+
+    private function convertRequest($psr7request, $original)
+    {
+        $clone = clone $original;
+
+        $foundation_request = (new HttpFoundationFactory())->createRequest($psr7request);
+
+        $clone->attributes = $foundation_request->attributes;
+        $clone->request = $foundation_request->request;
+        $clone->server = $foundation_request->server;
+        $clone->query = $foundation_request->query;
+        $clone->files = $foundation_request->files;
+        $clone->cookies = $foundation_request->cookies;
+        $clone->headers = $foundation_request->headers;
+
+        $clone->setRequestFormat($foundation_request->getRequestFormat());
+        $clone->setDefaultLocale($foundation_request->getDefaultLocale());
+        $clone->setLocale($foundation_request->getLocale());
+        if ($foundation_request->hasSession()) {
+            $clone->setSession($foundation_request->getSession());
+        }
+
+        return $clone;
     }
 
     private function convertResponse($psr7response, $original)
     {
+        $clone = clone $original;
+
         $foundation_response = (new HttpFoundationFactory())->createResponse($psr7response);
 
         foreach ($foundation_response->headers as $key => $value) {
-            $original->headers->set($key, $value);
+            $clone->headers->set($key, $value);
         }
-        $original->setContent($foundation_response->getContent());
-        $original->setProtocolVersion($foundation_response->getProtocolVersion());
-        $original->setStatusCode($foundation_response->getStatusCode());
-        $original->setCharset($foundation_response->getCharset());
+        $clone->setContent($foundation_response->getContent());
+        $clone->setProtocolVersion($foundation_response->getProtocolVersion());
+        $clone->setStatusCode($foundation_response->getStatusCode());
+        $clone->setCharset($foundation_response->getCharset());
 
-        return $original;
+        return $clone;
     }
 }

--- a/src/Psr15MiddlewareHandler.php
+++ b/src/Psr15MiddlewareHandler.php
@@ -33,4 +33,9 @@ class Handler implements RequestHandlerInterface
     {
         $this->response = $response;
     }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }

--- a/src/Psr15MiddlewareServiceProvider.php
+++ b/src/Psr15MiddlewareServiceProvider.php
@@ -21,27 +21,34 @@ class Psr15MiddlewareServiceProvider extends ServiceProvider
 
         if ($config->get('psr15middleware')) {
             foreach ($config->get('psr15middleware.middleware') as $key => $middleware) {
-                $this->app->singleton('Psr15MiddlewareMiddleware'.$key, function () use ($middleware) {
-                    return new \Jshannon63\Psr15Middleware\Psr15Middleware($middleware[0], $middleware[1]);
+                $this->app->singleton('psr15.middleware.'.$key, function () use ($middleware) {
+                    return new Psr15Middleware($middleware[0], $middleware[2]);
                 });
-                dd($this->app['Psr15MiddlewareMiddleware'.$key]);
-
-                $this->app[\Illuminate\Contracts\Http\Kernel::class]->pushMiddleware('Psr15MiddlewareMiddleware'.$key);
+                if ($middleware[1] == 'prepend') {
+                    $this->app[\Illuminate\Contracts\Http\Kernel::class]->prependMiddleware('psr15.middleware.'.$key);
+                } else {
+                    $this->app[\Illuminate\Contracts\Http\Kernel::class]->pushMiddleware('psr15.middleware.'.$key);
+                }
             }
             foreach ($config->get('psr15middleware.groups') as $groupkey => $group) {
                 foreach ($config->get('psr15middleware.groups.'.$groupkey) as $key => $middleware) {
-                    $this->app->bind('Psr15MiddlewareGroup'.title_case($groupkey).$key, function () use ($middleware) {
-                        return new Psr15Middleware($middleware[0], $middleware[1]);
+                    $this->app->bind('psr15.group.'.strtolower($groupkey).'.'.$key, function () use ($middleware) {
+                        return new Psr15Middleware($middleware[0], $middleware[2]);
                     });
-                    $this->app['router']->pushMiddlewareToGroup($groupkey, 'Psr15MiddlewareGroup'.title_case($groupkey).$key);
+                    if ($middleware[1] == 'prepend') {
+                        $this->app['router']->prependMiddlewareToGroup($groupkey, 'psr15.group.'.strtolower($groupkey).'.'.$key);
+                    } else {
+                        $this->app['router']->pushMiddlewareToGroup($groupkey, 'psr15.group.'.strtolower($groupkey).'.'.$key);
+                    }
                 }
             }
             foreach ($config->get('psr15middleware.aliases') as $key => $middleware) {
-                $this->app->bind('Psr15MiddlewareAlias'.title_case($key), function () use ($middleware) {
-                    return new Psr15Middleware($middleware[0], $middleware[1]);
+                $this->app->bind('psr15.alias.'.strtolower($key), function () use ($middleware) {
+                    return new Psr15Middleware($middleware[0], $middleware[2]);
                 });
-                $this->app['router']->aliasMiddleware($key, 'Psr15MiddlewareAlias'.title_case($key));
+                $this->app['router']->aliasMiddleware($key, 'psr15.alias.'.strtolower($key));
             }
+            // dd($this);
         }
     }
 

--- a/src/exampleMiddleware.php
+++ b/src/exampleMiddleware.php
@@ -9,31 +9,43 @@ use Psr\Http\Message\ResponseInterface;
 
 class exampleMiddleware implements MiddlewareInterface
 {
-    public function __construct()
+    protected $message;
+
+    public function __construct($parm1 = 'Hello', $parm2 = 'World')
     {
-        // if needed
+        $this->message = $parm1.' '.$parm2;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        // process any request manipulations here before the handler.
+        // remember that only "before" middlewares have access to
+        // the request object before the application acts on it.
+
         $response = $handler->handle($request);
 
-        /**** Your middleware functionality begins here ****/
+        // response actions go here after the handler provides
+        // you with a response object. keep in mind that any
+        // "before" middlewares will only have access to a mock
+        // response object and any updates will be lost.
 
-            $response->getBody()->rewind();
-            $body = $response->getBody();
-            $contents = $body->getContents();
-            $contents = str_replace(
-                "<body>",
-                "<body>\n\t<h1>PSR-15 Middleware Rocks!</h1>",
+        $response->getBody()->rewind();
+        $body = $response->getBody();
+        $contents = $body->getContents();
+        $contents = str_replace(
+                '<body>',
+                "<body>\n\t<h1>".$this->message.'</h1>',
                 $contents
             );
-            $body->rewind();
-            $body->write($contents);
+        $body->rewind();
+        $body->write($contents);
 
-        /**** and ends here ****/
+        // return the reponse object here.
+        // "terminable" middlewares run after the response has
+        // been sent back to the browser. they will receive the
+        // request object passed into this method and will get
+        // a copy of the  response object from the handler.
 
         return $response->withBody($body);
     }
 }
-

--- a/src/exampleMiddleware.php
+++ b/src/exampleMiddleware.php
@@ -21,6 +21,8 @@ class exampleMiddleware implements MiddlewareInterface
         // process any request manipulations here before the handler.
         // remember that only "before" middlewares have access to
         // the request object before the application acts on it.
+        // the handler will ensure the next middleware will see any
+        // changes to the request object.
 
         $response = $handler->handle($request);
 

--- a/tests/Psr15MiddlewareTest.php
+++ b/tests/Psr15MiddlewareTest.php
@@ -4,9 +4,8 @@ namespace Tests;
 
 use Jshannon63\Psr15Middleware\Psr15Middleware;
 
-require_once __DIR__."/../src/Psr15MiddlewareDispatcher.php";
-require_once __DIR__."/../src/Psr15MiddlewareHandler.php";
-
+require_once __DIR__.'/../src/Psr15MiddlewareDispatcher.php';
+require_once __DIR__.'/../src/Psr15MiddlewareHandler.php';
 
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
@@ -18,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 
-
 class exampleMiddleware1 implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -28,7 +26,7 @@ class exampleMiddleware1 implements MiddlewareInterface
         $response->getBody()->rewind();
         $body = $response->getBody();
         $contents = $body->getContents();
-        $contents .= "<h1>Test-1</h1>";
+        $contents .= '<h1>Test-1</h1>';
         $body->rewind();
         $body->write($contents);
 
@@ -45,7 +43,7 @@ class exampleMiddleware2 implements MiddlewareInterface
         $response->getBody()->rewind();
         $body = $response->getBody();
         $contents = $body->getContents();
-        $contents .= "<h1>Test-2</h1>";
+        $contents .= '<h1>Test-2</h1>';
         $body->rewind();
         $body->write($contents);
 
@@ -62,7 +60,7 @@ class exampleMiddleware3 implements MiddlewareInterface
         $response->getBody()->rewind();
         $body = $response->getBody();
         $contents = $body->getContents();
-        $contents .= "<h1>Test-3</h1>";
+        $contents .= '<h1>Test-3</h1>';
         $body->rewind();
         $body->write($contents);
 
@@ -76,12 +74,11 @@ class exampleMiddleware4 implements MiddlewareInterface
     {
         $response = $handler->handle($request);
 
-        $request->withHeader('X-PHPUNIT-TEST','PASSED');
+        $request->withHeader('X-PHPUNIT-TEST', 'PASSED');
 
         return $response;
     }
 }
-
 
 class Psr15MiddlewareTest extends TestCase
 {
@@ -94,34 +91,33 @@ class Psr15MiddlewareTest extends TestCase
         parent::setUp();
         $this->middleware = [
             'psr15middleware.middleware' => [
-                \Tests\exampleMiddleware1::class,
-                function(){
+                [\Tests\exampleMiddleware1::class, 'after'],
+                [function () {
                     return new \Tests\exampleMiddleware2();
-                },
-                (new \Tests\exampleMiddleware3()),
-                (new \Tests\exampleMiddleware4())
+                }, 'after'],
+                [(new \Tests\exampleMiddleware3()), 'after'],
+                [(new \Tests\exampleMiddleware4()), 'after']
             ]
         ];
         $this->container = new Container;
         $this->config = new Repository($this->middleware);
     }
 
-    public function test_middleware_stack(){
-
+    public function test_middleware_stack()
+    {
         $request = Request::create('http://localhost:8888/test/1', 'GET', [], [], [], [], null);
-        $response = new Response('Original Content:', Response::HTTP_OK, array('content-type' => 'text/html'));
+        $response = new Response('Original Content:', Response::HTTP_OK, ['content-type' => 'text/html']);
 
-        $psr15middleware = new Psr15Middleware($this->config,'middleware');
+        $psr15middleware = new Psr15Middleware($this->config, 'middleware');
 
-        $result = $psr15middleware->handle($request, function() use ($response){
+        $result = $psr15middleware->handle($request, function () use ($response) {
             return $response;
         });
 
-        $this->assertContains('Original Content:',$result->getContent());
-        $this->assertContains('Test-1',$result->getContent());
-        $this->assertContains('Test-2',$result->getContent());
-        $this->assertContains('Test-3',$result->getContent());
-        $this->assertContains('Original Content:<h1>Test-1</h1><h1>Test-2</h1><h1>Test-3</h1>',$result->getContent());
-
+        $this->assertContains('Original Content:', $result->getContent());
+        $this->assertContains('Test-1', $result->getContent());
+        $this->assertContains('Test-2', $result->getContent());
+        $this->assertContains('Test-3', $result->getContent());
+        $this->assertContains('Original Content:<h1>Test-1</h1><h1>Test-2</h1><h1>Test-3</h1>', $result->getContent());
     }
 }

--- a/tests/Psr15MiddlewareTest.php
+++ b/tests/Psr15MiddlewareTest.php
@@ -72,9 +72,9 @@ class exampleMiddleware4 implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $response = $handler->handle($request);
-
         $request->withHeader('X-PHPUNIT-TEST', 'PASSED');
+
+        $response = $handler->handle($request);
 
         return $response;
     }


### PR DESCRIPTION
Sweeping changes... breaking changes. Now supporting middleware types: before after and terminable. Also supporting priority middleware using prepend and append. Also, now we do not run as a separate middleware stack. Each PSR-15 middleware is encapsulated and integrated within the Laravel stack. Also, middleware constructors are now treated as variadic functions and parameters can be passed either from the configuration file for callable and object types or as route middleware parameters from Laravel routes.
  